### PR TITLE
chore: rebase project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,9 @@
-# Current Version: 1.1.9
-
 name: Build & Release hezhijie0327/CNIPDb
 
 on:
-    schedule:
-        - cron: "0 0 * * *"
-    workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
     build:
@@ -22,7 +20,7 @@ jobs:
               run: |
                   git clone --depth 1 "https://github.com/zhanhb/cidr-merger" && cd ./cidr-merger && go install . && cd .. && rm -rf ./cidr-merger
                   git clone --depth 1 "https://github.com/Loyalsoldier/geoip" && cd ./geoip && go install . && cd .. && rm -rf ./geoip
-                  curl -s "https://raw.githubusercontent.com/hezhijie0327/CNIPDb/source/release.sh" | sed "s/{GEOLITE2\_TOKEN}/${{ secrets.GEOLITE2_TOKEN }}/g;s/{IP2LOCATION\_TOKEN}/${{ secrets.IP2LOCATION_TOKEN }}/g;s/{IPINFOIO\_TOKEN}/${{ secrets.IPINFOIO_TOKEN }}/g" | sudo bash
+                  cat release.sh | sed "s/{GEOLITE2\_TOKEN}/${{ secrets.GEOLITE2_TOKEN }}/g;s/{IP2LOCATION\_TOKEN}/${{ secrets.IP2LOCATION_TOKEN }}/g;s/{IPINFOIO\_TOKEN}/${{ secrets.IPINFOIO_TOKEN }}/g" | bash
             - name: Step 4 - Release CNIPDb
               run: |
                   curl -s "https://raw.githubusercontent.com/hezhijie0327/Toolkit/main/Git.sh" > "/tmp/Git.sh"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,207 @@
+Copyright 2026 Zhijie He
+
+Licensed under the Apache License, Version 2.0 with Commons Clause v1.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+    https://commonsclause.com/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+===========================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+===========================================================================
+
+Commons Clause License Condition v1.0
+
+The Software is provided to you by the Licensor under the Apache License, as defined above, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Clause License Condition notice.
+
+Software: CNIPDb
+License: Apache 2.0 with Commons Clause v1.0
+Licensor: Zhijie He

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,355 @@
+#!/bin/bash
+
+## How to get and use?
+# git clone "https://github.com/hezhijie0327/CNIPDb.git" && bash ./CNIPDb/release.sh
+
+## Parameter
+CRUL_OPTION=""
+
+## Function
+# Environment Preparation
+function EnvironmentPreparation() {
+    export DEBIAN_FRONTEND="noninteractive"
+    export PATH="/home/runner/go/bin:$PATH"
+    rm -rf ./Temp && mkdir ./Temp && cd ./Temp
+}
+# Environment Cleanup
+function EnvironmentCleanup() {
+    ZJDBIP_SOURCE=($(ls ../ | grep 'cnipdb_' | grep -v "cnipdb_zjdb\|cnipdb_btpanel" | awk "{ print $2 }"))
+    ZJDBIP_SOURCE_IPv4="" && ZJDBIP_SOURCE_IPv6="" && for ZJDBIP_SOURCE_TASK in "${!ZJDBIP_SOURCE[@]}"; do
+        if [ -f "../${ZJDBIP_SOURCE[$ZJDBIP_SOURCE_TASK]}/country_ipv4.txt" ]; then
+            ZJDBIP_SOURCE_IPv4="${ZJDBIP_SOURCE_IPv4}../${ZJDBIP_SOURCE[$ZJDBIP_SOURCE_TASK]}/country_ipv4.txt "
+        fi
+        if [ -f "../${ZJDBIP_SOURCE[$ZJDBIP_SOURCE_TASK]}/country_ipv6.txt" ]; then
+            ZJDBIP_SOURCE_IPv6="${ZJDBIP_SOURCE_IPv6}../${ZJDBIP_SOURCE[$ZJDBIP_SOURCE_TASK]}/country_ipv6.txt "
+        fi
+        ZJDBIP_SOURCE_IPv4=$(echo "${ZJDBIP_SOURCE_IPv4}" | sed "s/^\ //g")
+        ZJDBIP_SOURCE_IPv6=$(echo "${ZJDBIP_SOURCE_IPv6}" | sed "s/^\ //g")
+    done
+    mkdir -p ../cnipdb_zjdb
+    cat ${ZJDBIP_SOURCE_IPv4} | sort | uniq | cidr-merger -s > ../cnipdb_zjdb/country_ipv4.txt
+    cat ${ZJDBIP_SOURCE_IPv6} | sort | uniq | cidr-merger -s > ../cnipdb_zjdb/country_ipv6.txt
+    cat ../cnipdb_zjdb/country_ipv4.txt ../cnipdb_zjdb/country_ipv6.txt > ../cnipdb_zjdb/country_ipv4_6.txt
+    GIT_STATUS=($(git status -s | grep "A\|M\|\?" | grep 'country_ipv' | cut -d ' ' -f 3 | grep "txt" | cut -d '/' -f 2-3 | sed 's/cnipdb_//g;s/country_//g;s/.txt//g' | awk "{ print $2 }"))
+    for GIT_STATUS_TASK in "${!GIT_STATUS[@]}"; do
+        geoip -c "https://raw.githubusercontent.com/hezhijie0327/CNIPDb/main/script/${GIT_STATUS[$GIT_STATUS_TASK]}.json"
+    done
+    cd .. && rm -rf ./Temp
+}
+# Get Data from BGP
+function GetDataFromBGP() {
+    bgp_url=(
+        "https://raw.githubusercontent.com/gaoyifan/china-operator-ip/ip-lists/china6.txt"
+        "https://raw.githubusercontent.com/gaoyifan/china-operator-ip/ip-lists/china.txt"
+        "https://raw.githubusercontent.com/misakaio/chnroutes2/master/chnroutes.txt"
+    )
+    for bgp_url_task in "${!bgp_url[@]}"; do
+        curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${bgp_url[$bgp_url_task]}" >> ./bgp_country_ipv4_6.tmp
+    done
+    bgp_country_ipv4_data=($(cat ./bgp_country_ipv4_6.tmp | grep -v "\:\|\#" | grep '.' | sort | uniq | awk "{ print $2 }"))
+    bgp_country_ipv6_data=($(cat ./bgp_country_ipv4_6.tmp | grep -v "\.\|\#" | grep ':' | sort | uniq | awk "{ print $2 }"))
+    for bgp_country_ipv4_data_task in "${!bgp_country_ipv4_data[@]}"; do
+        echo "${bgp_country_ipv4_data[$bgp_country_ipv4_data_task]}" >> ./bgp_country_ipv4.tmp
+    done
+    for bgp_country_ipv6_data_task in "${!bgp_country_ipv6_data[@]}"; do
+        echo "${bgp_country_ipv6_data[$bgp_country_ipv6_data_task]}" >> ./bgp_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_bgp
+    cat ./bgp_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_bgp/country_ipv4.txt
+    cat ./bgp_country_ipv6.tmp | sort | uniq | cidr-merger -s > ../cnipdb_bgp/country_ipv6.txt
+    cat ../cnipdb_bgp/country_ipv4.txt ../cnipdb_bgp/country_ipv6.txt > ../cnipdb_bgp/country_ipv4_6.txt
+}
+# Get Data from BTPanel
+function GetDataFromBTPanel() {
+    btpanel_url=(
+        "https://download.bt.cn/cnlist.json"
+    )
+    for btpanel_url_task in "${!btpanel_url[@]}"; do
+        curl -s --connect-timeout 15 "${btpanel_url[$btpanel_url_task]}" >> ./btpanel_country_ipv4_6.tmp
+    done
+    btpanel_country_ipv4_data=($(cat ./btpanel_country_ipv4_6.tmp | sed 's/]], /\n/g' | sed "s/\], \[/-/g" | tr -d '[ ]' | sed 's/,/./g' | sort | uniq | awk "{ print $2 }"))
+    for btpanel_country_ipv4_data_task in "${!btpanel_country_ipv4_data[@]}"; do
+        echo "${btpanel_country_ipv4_data[$btpanel_country_ipv4_data_task]}" >> ./btpanel_country_ipv4.tmp
+    done
+    mkdir ../cnipdb_btpanel
+    cat ./btpanel_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_btpanel/country_ipv4.txt
+}
+# Get Data from DBIP
+function GetDataFromDBIP() {
+    dbip_url=(
+        "https://download.db-ip.com/free/dbip-country-lite-$(date '+%Y-%m').csv.gz"
+    )
+    for dbip_url_task in "${!dbip_url[@]}"; do
+        curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${dbip_url[$dbip_url_task]}" >> ./dbip_${dbip_url_task}.csv.gz
+        gzip -d ./dbip_${dbip_url_task}.csv.gz && mv ./dbip_${dbip_url_task}.csv ./$(echo ${dbip_url[$dbip_url_task]} | cut -d '/' -f 5 | cut -d '.' -f 1,2)
+    done
+    dbip_country_ipv4_data=($(cat ./dbip-country-lite-$(date '+%Y-%m').csv | grep 'CN' | cut -d ',' -f 1,2 | tr ',' '-' | grep -v ':' | sort | uniq | awk "{ print $2 }"))
+    dbip_country_ipv6_data=($(cat ./dbip-country-lite-$(date '+%Y-%m').csv | grep 'CN' | cut -d ',' -f 1,2 | tr ',' '-' | grep ':' | sort | uniq | awk "{ print $2 }"))
+    for dbip_country_ipv4_data_task in "${!dbip_country_ipv4_data[@]}"; do
+        echo "${dbip_country_ipv4_data[$dbip_country_ipv4_data_task]}" >> ./dbip_country_ipv4.tmp
+    done
+    for dbip_country_ipv6_data_task in "${!dbip_country_ipv6_data[@]}"; do
+        echo "${dbip_country_ipv6_data[$dbip_country_ipv6_data_task]}" >> ./dbip_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_dbip
+    cat ./dbip_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_dbip/country_ipv4.txt
+    cat ./dbip_country_ipv6.tmp | sort | uniq | cidr-merger -s > ../cnipdb_dbip/country_ipv6.txt
+    cat ../cnipdb_dbip/country_ipv4.txt ../cnipdb_dbip/country_ipv6.txt > ../cnipdb_dbip/country_ipv4_6.txt
+}
+# Get Data from GeoLite2
+function GetDataFromGeoLite2() {
+    geolite2_url=(
+        "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&license_key={GEOLITE2_TOKEN}&suffix=zip"
+    )
+    for geolite2_url_task in "${!geolite2_url[@]}"; do
+        curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${geolite2_url[$geolite2_url_task]}" >> ./geolite2_${geolite2_url_task}.zip
+        unzip -o -d . ./geolite2_${geolite2_url_task}.zip && rm -rf ./geolite2_${geolite2_url_task}.zip
+    done
+    geolite2_country_ipv4_data=($(cat ./GeoLite2-Country-CSV_*/GeoLite2-Country-Blocks-IPv4.csv | grep '1814991,1814991' | cut -d ',' -f 1 | sort | uniq | awk "{ print $2 }"))
+    geolite2_country_ipv6_data=($(cat ./GeoLite2-Country-CSV_*/GeoLite2-Country-Blocks-IPv6.csv | grep '1814991,1814991' | cut -d ',' -f 1 | sort | uniq | awk "{ print $2 }"))
+    for geolite2_country_ipv4_data_task in "${!geolite2_country_ipv4_data[@]}"; do
+        echo "${geolite2_country_ipv4_data[$geolite2_country_ipv4_data_task]}" >> ./geolite2_country_ipv4.tmp
+    done
+    for geolite2_country_ipv6_data_task in "${!geolite2_country_ipv6_data[@]}"; do
+        echo "${geolite2_country_ipv6_data[$geolite2_country_ipv6_data_task]}" >> ./geolite2_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_geolite2
+    cat ./geolite2_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_geolite2/country_ipv4.txt
+    cat ./geolite2_country_ipv6.tmp | sort | uniq | cidr-merger -s > ../cnipdb_geolite2/country_ipv6.txt
+    cat ../cnipdb_geolite2/country_ipv4.txt ../cnipdb_geolite2/country_ipv6.txt > ../cnipdb_geolite2/country_ipv4_6.txt
+}
+# Get Data from IANA
+function GetDataFromIANA() {
+    iana_url=(
+        "https://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-extended-latest"
+        "https://ftp.afrinic.net/pub/stats/afrinic/delegated-afrinic-latest"
+        "https://ftp.apnic.net/stats/apnic/delegated-apnic-extended-latest"
+        "https://ftp.apnic.net/stats/apnic/delegated-apnic-latest"
+        "https://ftp.apnic.net/stats/iana/delegated-iana-latest"
+        "https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest"
+        "https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest"
+        "https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-latest"
+        "https://ftp.ripe.net/ripe/stats/delegated-ripencc-extended-latest"
+        "https://ftp.ripe.net/ripe/stats/delegated-ripencc-latest"
+    )
+    for iana_url_task in "${!iana_url[@]}"; do
+        curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${iana_url[$iana_url_task]}" >> ./iana_url.tmp
+    done
+    iana_country_ipv4_data=($(cat ./iana_url.tmp | grep "CN|ipv4" | sort | uniq | awk "{ print $2 }"))
+    iana_country_ipv6_data=($(cat ./iana_url.tmp | grep "CN|ipv6" | sort | uniq | awk "{ print $2 }"))
+    for iana_country_ipv4_data_task in "${!iana_country_ipv4_data[@]}"; do
+        echo "$(echo $(echo ${iana_country_ipv4_data[$iana_country_ipv4_data_task]} | awk -F '|' '{ print $4 }')/$(echo ${iana_country_ipv4_data[$iana_country_ipv4_data_task]} | awk -F '|' '{ print 32 - log($5) / log(2) }'))" >> ./iana_country_ipv4.tmp
+    done
+    for iana_country_ipv6_data_task in "${!iana_country_ipv6_data[@]}"; do
+        echo "$(echo $(echo ${iana_country_ipv6_data[$iana_country_ipv6_data_task]} | awk -F '|' '{ print $4 }')/$(echo ${iana_country_ipv6_data[$iana_country_ipv6_data_task]} | awk -F '|' '{ print $5 }'))" >> ./iana_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_iana
+    cat ./iana_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_iana/country_ipv4.txt
+    cat ./iana_country_ipv6.tmp | sort | uniq | cidr-merger -s > ../cnipdb_iana/country_ipv6.txt
+    cat ../cnipdb_iana/country_ipv4.txt ../cnipdb_iana/country_ipv6.txt > ../cnipdb_iana/country_ipv4_6.txt
+}
+# Get Data from IP2Location
+function GetDataFromIP2Location() {
+    function IPv4NUMConvert() {
+        IPv4_ADDR=""
+        W=$(echo "obase=10;($IP_NUM / (256^3)) % 256" | bc)
+        X=$(echo "obase=10;($IP_NUM / (256^2)) % 256" | bc)
+        Y=$(echo "obase=10;($IP_NUM / (256^1)) % 256" | bc)
+        Z=$(echo "obase=10;($IP_NUM / (256^0)) % 256" | bc)
+        IPv4_ADDR="$W.$X.$Y.$Z"
+    }
+    function IPv6NUMConvert() {
+        IPv6_ADDR=""
+        A=$(echo "obase=16;($IP_NUM / (65536^7)) % 65536" | bc)
+        B=$(echo "obase=16;($IP_NUM / (65536^6)) % 65536" | bc)
+        C=$(echo "obase=16;($IP_NUM / (65536^5)) % 65536" | bc)
+        D=$(echo "obase=16;($IP_NUM / (65536^4)) % 65536" | bc)
+        E=$(echo "obase=16;($IP_NUM / (65536^3)) % 65536" | bc)
+        F=$(echo "obase=16;($IP_NUM / (65536^2)) % 65536" | bc)
+        G=$(echo "obase=16;($IP_NUM / (65536^1)) % 65536" | bc)
+        H=$(echo "obase=16;($IP_NUM / (65536^0)) % 65536" | bc)
+        IPv6_ADDR="$A:$B:$C:$D:$E:$F:$G:$H"
+    }
+    ip2location_url=(
+        "https://www.ip2location.com/download/?token={IP2LOCATION_TOKEN}&file=DB1LITECSVIPV6"
+        "https://www.ip2location.com/download/?token={IP2LOCATION_TOKEN}&file=DB1LITECSV"
+    )
+    for ip2location_url_task in "${!ip2location_url[@]}"; do
+        curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${ip2location_url[$ip2location_url_task]}" >> ./ip2location_${ip2location_url_task}.zip
+        unzip -o -d . ./ip2location_${ip2location_url_task}.zip && rm -rf ./ip2location_${ip2location_url_task}.zip
+    done
+    ip2location_country_ipv4_data=($(cat ./IP2LOCATION-LITE-DB1.CSV | grep '"CN","China"' | cut -d ',' -f 1,2 | tr -d '"' | tr ',' '-' | sort | uniq | awk "{ print $2 }"))
+    ip2location_country_ipv6_data=($(cat ./IP2LOCATION-LITE-DB1.IPV6.CSV | grep '"CN","China"' | cut -d ',' -f 1,2 | tr -d '"' | tr ',' '-' | sort | uniq | awk "{ print $2 }"))
+    for ip2location_country_ipv4_data_task in "${!ip2location_country_ipv4_data[@]}"; do
+        IP_NUM=$(echo "${ip2location_country_ipv4_data[$ip2location_country_ipv4_data_task]}" | cut -d '-' -f 1) && IPv4NUMConvert && IPv4_ADDR_START="${IPv4_ADDR}"
+        IP_NUM=$(echo "${ip2location_country_ipv4_data[$ip2location_country_ipv4_data_task]}" | cut -d '-' -f 2) && IPv4NUMConvert && IPv4_ADDR_END="${IPv4_ADDR}"
+        echo "${IPv4_ADDR_START}-${IPv4_ADDR_END}" >> ./ip2location_country_ipv4.tmp
+    done
+    for ip2location_country_ipv6_data_task in "${!ip2location_country_ipv6_data[@]}"; do
+        IP_NUM=$(echo "${ip2location_country_ipv6_data[$ip2location_country_ipv6_data_task]}" | cut -d '-' -f 1) && IPv6NUMConvert && IPv6_ADDR_START="${IPv6_ADDR}"
+        IP_NUM=$(echo "${ip2location_country_ipv6_data[$ip2location_country_ipv6_data_task]}" | cut -d '-' -f 2) && IPv6NUMConvert && IPv6_ADDR_END="${IPv6_ADDR}"
+        echo "${IPv6_ADDR_START}-${IPv6_ADDR_END}" >> ./ip2location_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_ip2location
+    cat ./ip2location_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_ip2location/country_ipv4.txt
+    cat ./ip2location_country_ipv6.tmp | sort | uniq | cidr-merger -s | grep -v '^::ffff:' > ../cnipdb_ip2location/country_ipv6.txt
+    cat ../cnipdb_ip2location/country_ipv4.txt ../cnipdb_ip2location/country_ipv6.txt > ../cnipdb_ip2location/country_ipv4_6.txt
+}
+# Get Data from IPinfo.io
+function GetDataFromIPinfoio() {
+    ipinfoio_url=(
+        "https://ipinfo.io/data/free/country.csv.gz?token={IPINFOIO_TOKEN}"
+    )
+    for ipinfoio_url_task in "${!ipinfoio_url[@]}"; do
+        curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${ipinfoio_url[$ipinfoio_url_task]}" >> ./ipinfoio_${ipinfoio_url_task}.csv.gz
+        gzip -d ./ipinfoio_${ipinfoio_url_task}.csv.gz
+    done
+    ipinfoio_country_ipv4_data=($(cat ./ipinfoio_*.csv | grep 'CN' | cut -d ',' -f 1,2 | tr ',' '-' | grep -v ':' | sort | uniq | awk "{ print $2 }"))
+    ipinfoio_country_ipv6_data=($(cat ./ipinfoio_*.csv | grep 'CN' | cut -d ',' -f 1,2 | tr ',' '-' | grep ':' | sort | uniq | awk "{ print $2 }"))
+    for ipinfoio_country_ipv4_data_task in "${!ipinfoio_country_ipv4_data[@]}"; do
+        echo "${ipinfoio_country_ipv4_data[$ipinfoio_country_ipv4_data_task]}" >> ./ipinfoio_country_ipv4.tmp
+    done
+    for ipinfoio_country_ipv6_data_task in "${!ipinfoio_country_ipv6_data[@]}"; do
+        echo "${ipinfoio_country_ipv6_data[$ipinfoio_country_ipv6_data_task]}" >> ./ipinfoio_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_ipinfoio
+    cat ./ipinfoio_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_ipinfoio/country_ipv4.txt
+    cat ./ipinfoio_country_ipv6.tmp | sort | uniq | cidr-merger -s > ../cnipdb_ipinfoio/country_ipv6.txt
+    cat ../cnipdb_ipinfoio/country_ipv4.txt ../cnipdb_ipinfoio/country_ipv6.txt > ../cnipdb_ipinfoio/country_ipv4_6.txt
+}
+function GetDataFromIPdeny() {
+    ipdeny_url=(
+        "http://www.ipdeny.com/ipblocks/data/aggregated/cn-aggregated.zone"
+        "http://www.ipdeny.com/ipv6/ipaddresses/aggregated/cn-aggregated.zone"
+    )
+    for ipdeny_url_task in "${!ipdeny_url[@]}"; do
+        curl -s --connect-timeout 15 "${ipdeny_url[$ipdeny_url_task]}" >> ./ipdeny_country_ipv4_6.tmp
+    done
+    ipdeny_country_ipv4_data=($(cat ./ipdeny_country_ipv4_6.tmp | grep -v "\:\|\#" | grep '.' | sort | uniq | awk "{ print $2 }"))
+    ipdeny_country_ipv6_data=($(cat ./ipdeny_country_ipv4_6.tmp | grep -v "\.\|\#" | grep ':' | sort | uniq | awk "{ print $2 }"))
+    for ipdeny_country_ipv4_data_task in "${!ipdeny_country_ipv4_data[@]}"; do
+        echo "${ipdeny_country_ipv4_data[$ipdeny_country_ipv4_data_task]}" >> ./ipdeny_country_ipv4.tmp
+    done
+    for ipdeny_country_ipv6_data_task in "${!ipdeny_country_ipv6_data[@]}"; do
+        echo "${ipdeny_country_ipv6_data[$ipdeny_country_ipv6_data_task]}" >> ./ipdeny_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_ipdeny
+    cat ./ipdeny_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_ipdeny/country_ipv4.txt
+    cat ./ipdeny_country_ipv6.tmp | sort | uniq | cidr-merger -s > ../cnipdb_ipdeny/country_ipv6.txt
+    cat ../cnipdb_ipdeny/country_ipv4.txt ../cnipdb_ipdeny/country_ipv6.txt > ../cnipdb_ipdeny/country_ipv4_6.txt
+}
+# Get Data from IPIPdotNET
+function GetDataFromIPIPdotNET() {
+    ipipdotnet_url=(
+        "https://cdn.ipip.net/17mon/country.zip"
+        "https://raw.githubusercontent.com/17mon/china_ip_list/master/china_ip_list.txt"
+        "https://raw.githubusercontent.com/zhufengme/block_cn_files/refs/heads/master/cn_ip_list.txt"
+    )
+    for ipipdotnet_url_task in "${!ipipdotnet_url[@]}"; do
+        if [ "$(echo ${ipipdotnet_url[$ipipdotnet_url_task]} | grep '.zip$')" ]; then
+            curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${ipipdotnet_url[$ipipdotnet_url_task]}" >> ./ipipdotnet_${ipipdotnet_url_task}.zip
+            unzip -o -d . ./ipipdotnet_${ipipdotnet_url_task}.zip && rm -rf ./ipipdotnet_${ipipdotnet_url_task}.zip
+        else
+            curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${ipipdotnet_url[$ipipdotnet_url_task]}" >> ./ipipdotnet_country_ipv4_6_raw.tmp
+        fi
+    done
+    ipipdotnet_country_ipv4_data=(
+        $(cat ./country.txt | grep 'CN$' | cut -f 1 | sort | uniq | awk "{ print $2 }")
+        $(cat ./ipipdotnet_country_ipv4_6_raw.tmp | grep -v "\:" | grep '.' | sort | uniq | awk "{ print $2 }")
+    )
+    for ipipdotnet_country_ipv4_data_task in "${!ipipdotnet_country_ipv4_data[@]}"; do
+        echo "${ipipdotnet_country_ipv4_data[$ipipdotnet_country_ipv4_data_task]}" >> ./ipipdotnet_country_ipv4.tmp
+    done
+    mkdir -p ../cnipdb_ipipdotnet
+    cat ./ipipdotnet_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_ipipdotnet/country_ipv4.txt
+}
+# Get Data from IPtoASN
+function GetDataFromIPtoASN() {
+    iptoasn_url=(
+        "https://iptoasn.com/data/ip2country-v4.tsv.gz"
+        "https://iptoasn.com/data/ip2country-v6.tsv.gz"
+    )
+    for iptoasn_url_task in "${!iptoasn_url[@]}"; do
+        curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${iptoasn_url[$iptoasn_url_task]}" >> ./iptoasn_${iptoasn_url_task}.tsv.gz
+        gzip -d ./iptoasn_${iptoasn_url_task}.tsv.gz && mv ./iptoasn_${iptoasn_url_task}.tsv ./$(echo ${iptoasn_url[$iptoasn_url_task]} | cut -d '/' -f 5 | cut -d '.' -f 1,2)
+    done
+    iptoasn_country_ipv4_data=($(cat ./ip2country-v4.tsv | grep 'CN' | cut -f 1,2 | tr '\t' '-' | sort | uniq | awk "{ print $2 }"))
+    iptoasn_country_ipv6_data=($(cat ./ip2country-v6.tsv | grep 'CN' | cut -f 1,2 | tr '\t' '-' | sort | uniq | awk "{ print $2 }"))
+    for iptoasn_country_ipv4_data_task in "${!iptoasn_country_ipv4_data[@]}"; do
+        echo "${iptoasn_country_ipv4_data[$iptoasn_country_ipv4_data_task]}" >> ./iptoasn_country_ipv4.tmp
+    done
+    for iptoasn_country_ipv6_data_task in "${!iptoasn_country_ipv6_data[@]}"; do
+        echo "${iptoasn_country_ipv6_data[$iptoasn_country_ipv6_data_task]}" >> ./iptoasn_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_iptoasn
+    cat ./iptoasn_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_iptoasn/country_ipv4.txt
+    cat ./iptoasn_country_ipv6.tmp | sort | uniq | cidr-merger -s > ../cnipdb_iptoasn/country_ipv6.txt
+    cat ../cnipdb_iptoasn/country_ipv4.txt ../cnipdb_iptoasn/country_ipv6.txt > ../cnipdb_iptoasn/country_ipv4_6.txt
+}
+# Get Data from OpenIPDB
+function GetDataFromOpenIPDB() {
+    openipdb_url=(
+        "https://raw.githubusercontent.com/metowolf/iplist/master/data/country/CN.txt"
+    )
+    for openipdb_url_task in "${!openipdb_url[@]}"; do
+        curl -s --connect-timeout 15 "${openipdb_url[$openipdb_url_task]}" >> ./openipdb_country_ipv4_6.tmp
+    done
+    openipdb_country_ipv4_data=($(cat ./openipdb_country_ipv4_6.tmp | sort | uniq | awk "{ print $2 }"))
+    for openipdb_country_ipv4_data_task in "${!openipdb_country_ipv4_data[@]}"; do
+        echo "${openipdb_country_ipv4_data[$openipdb_country_ipv4_data_task]}" >> ./openipdb_country_ipv4.tmp
+    done
+    mkdir -p ../cnipdb_openipdb
+    cat ./openipdb_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_openipdb/country_ipv4.txt
+}
+# Get Data from VXLINK
+function GetDataFromVXLINK() {
+    vxlink_url=(
+        "https://raw.githubusercontent.com/tmplink/IPDB/main/ipv4/cidr/CN.txt"
+        "https://raw.githubusercontent.com/tmplink/IPDB/main/ipv6/cidr/CN.txt"
+    )
+    for vxlink_url_task in "${!vxlink_url[@]}"; do
+        curl ${CRUL_OPTION:--s --connect-timeout 15 -L} "${vxlink_url[$vxlink_url_task]}" >> ./vxlink_country_ipv4_6.tmp
+    done
+    vxlink_country_ipv4_data=($(cat ./vxlink_country_ipv4_6.tmp | grep -v "\:" | grep '.' | sort | uniq | awk "{ print $2 }"))
+    vxlink_country_ipv6_data=($(cat ./vxlink_country_ipv4_6.tmp | grep -v "\." | grep ':' | sort | uniq | awk "{ print $2 }"))
+    for vxlink_country_ipv4_data_task in "${!vxlink_country_ipv4_data[@]}"; do
+        echo "${vxlink_country_ipv4_data[$vxlink_country_ipv4_data_task]}" >> ./vxlink_country_ipv4.tmp
+    done
+    for vxlink_country_ipv6_data_task in "${!vxlink_country_ipv6_data[@]}"; do
+        echo "${vxlink_country_ipv6_data[$vxlink_country_ipv6_data_task]}" >> ./vxlink_country_ipv6.tmp
+    done
+    mkdir -p ../cnipdb_vxlink
+    cat ./vxlink_country_ipv4.tmp | sort | uniq | cidr-merger -s > ../cnipdb_vxlink/country_ipv4.txt
+    cat ./vxlink_country_ipv6.tmp | sort | uniq | cidr-merger -s > ../cnipdb_vxlink/country_ipv6.txt
+    cat ../cnipdb_vxlink/country_ipv4.txt ../cnipdb_vxlink/country_ipv6.txt > ../cnipdb_vxlink/country_ipv4_6.txt
+}
+
+## Process
+# Call EnvironmentPreparation
+EnvironmentPreparation
+# Call GetDataFromBGP
+GetDataFromBGP
+# Call GetDataFromBTPanel
+GetDataFromBTPanel
+# Call GetDataFromDBIP
+GetDataFromDBIP
+# Call GetDataFromGeoLite2
+GetDataFromGeoLite2
+# Call GetDataFromIANA
+GetDataFromIANA
+# Call GetDataFromIP2Location
+GetDataFromIP2Location
+# Cal GetDataFromIPdeny
+GetDataFromIPdeny
+# Call GetDataFromIPinfoio
+GetDataFromIPinfoio
+# Call GetDataFromIPIPdotNET
+GetDataFromIPIPdotNET
+# Call GetDataFromIPtoASN
+GetDataFromIPtoASN
+# Call GetDataFromOpenIPDB
+GetDataFromOpenIPDB
+# Call GetDataFromVXLINK
+GetDataFromVXLINK
+# Call EnvironmentCleanup
+EnvironmentCleanup

--- a/script/bgp/ipv4.json
+++ b/script/bgp/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_bgp/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_bgp",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_bgp",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/bgp/ipv4_6.json
+++ b/script/bgp/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_bgp/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_bgp",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_bgp",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/bgp/ipv6.json
+++ b/script/bgp/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_bgp/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_bgp",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_bgp",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/dbip/ipv4.json
+++ b/script/dbip/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_dbip/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_dbip",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_dbip",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/dbip/ipv4_6.json
+++ b/script/dbip/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_dbip/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_dbip",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_dbip",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/dbip/ipv6.json
+++ b/script/dbip/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_dbip/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_dbip",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_dbip",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/geolite2/ipv4.json
+++ b/script/geolite2/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_geolite2/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_geolite2",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_geolite2",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/geolite2/ipv4_6.json
+++ b/script/geolite2/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_geolite2/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_geolite2",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_geolite2",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/geolite2/ipv6.json
+++ b/script/geolite2/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_geolite2/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_geolite2",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_geolite2",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/iana/ipv4.json
+++ b/script/iana/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_iana/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_iana",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_iana",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/iana/ipv4_6.json
+++ b/script/iana/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_iana/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_iana",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_iana",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/iana/ipv6.json
+++ b/script/iana/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_iana/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_iana",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_iana",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/ip2location/ipv4.json
+++ b/script/ip2location/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_ip2location/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_ip2location",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_ip2location",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/ip2location/ipv4_6.json
+++ b/script/ip2location/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_ip2location/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_ip2location",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_ip2location",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/ip2location/ipv6.json
+++ b/script/ip2location/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_ip2location/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_ip2location",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_ip2location",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/ipinfoio/ipv4.json
+++ b/script/ipinfoio/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_ipinfoio/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_ipinfoio",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_ipinfoio",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/ipinfoio/ipv4_6.json
+++ b/script/ipinfoio/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_ipinfoio/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_ipinfoio",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_ipinfoio",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/ipinfoio/ipv6.json
+++ b/script/ipinfoio/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_ipinfoio/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_ipinfoio",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_ipinfoio",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/ipipdotnet/ipv4.json
+++ b/script/ipipdotnet/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_ipipdotnet/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_ipipdotnet",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_ipipdotnet",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/iptoasn/ipv4.json
+++ b/script/iptoasn/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_iptoasn/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_iptoasn",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_iptoasn",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/iptoasn/ipv4_6.json
+++ b/script/iptoasn/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_iptoasn/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_iptoasn",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_iptoasn",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/iptoasn/ipv6.json
+++ b/script/iptoasn/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_iptoasn/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_iptoasn",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_iptoasn",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/vxlink/ipv4.json
+++ b/script/vxlink/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_vxlink/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_vxlink",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_vxlink",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/vxlink/ipv4_6.json
+++ b/script/vxlink/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_vxlink/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_vxlink",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_vxlink",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/vxlink/ipv6.json
+++ b/script/vxlink/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_vxlink/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_vxlink",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_vxlink",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/zjdb/ipv4.json
+++ b/script/zjdb/ipv4.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_zjdb/country_ipv4.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_zjdb",
+        "outputName": "country_ipv4.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv4",
+        "outputDir": "../cnipdb_zjdb",
+        "outputName": "country_ipv4.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/zjdb/ipv4_6.json
+++ b/script/zjdb/ipv4_6.json
@@ -1,0 +1,30 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_zjdb/country_ipv4_6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_zjdb",
+        "outputName": "country_ipv4_6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "outputDir": "../cnipdb_zjdb",
+        "outputName": "country_ipv4_6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}

--- a/script/zjdb/ipv6.json
+++ b/script/zjdb/ipv6.json
@@ -1,0 +1,32 @@
+{
+  "input": [
+    {
+      "action": "add",
+      "args": {
+        "name": "cn",
+        "uri": "../cnipdb_zjdb/country_ipv6.txt"
+      },
+      "type": "text"
+    }
+  ],
+  "output": [
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_zjdb",
+        "outputName": "country_ipv6.dat"
+      },
+      "type": "v2rayGeoIPDat"
+    },
+    {
+      "action": "output",
+      "args": {
+        "onlyIPType": "ipv6",
+        "outputDir": "../cnipdb_zjdb",
+        "outputName": "country_ipv6.mmdb"
+      },
+      "type": "maxmindMMDB"
+    }
+  ]
+}


### PR DESCRIPTION
## 来自 Sourcery 的摘要

添加用于生成中国（CN）IP 数据库制品的本地发布流水线，并将其接入 GitHub Actions 工作流。

新功能：
- 引入一个功能全面的 `release.sh` 脚本，用于从多个外部数据提供方获取、聚合并生成 CN IP 数据集。
- 新增按提供方划分的 JSON 配置脚本和 LICENSE 文件，以支持对生成数据进行基于 geoip 的后处理。

增强：
- 更新 GitHub Actions 工作流，使其使用本地的 `release.sh` 脚本，而不是获取并执行远程发布脚本，并整理工作流 YAML 的格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a local release pipeline for generating CN IP database artifacts and wire it into the GitHub Actions workflow.

New Features:
- Introduce a comprehensive release.sh script to fetch, aggregate, and generate CN IP datasets from multiple external data providers.
- Add per-provider JSON configuration scripts and a LICENSE file to support geoip-based post-processing of generated data.

Enhancements:
- Update the GitHub Actions workflow to use the local release.sh script instead of fetching and executing a remote release script, and clean up workflow YAML formatting.

</details>